### PR TITLE
[fix] ジャンル/タグ検索のv-chipのトグル不具合修正 close #9

### DIFF
--- a/components/atoms/Genre.vue
+++ b/components/atoms/Genre.vue
@@ -32,8 +32,11 @@ export default {
         ? this.$emit('formGenreCheckedEvent', this.genre.genre_name)
         : this.$emit('formGenreUncheckedEvent', this.genre.genre_name)
     },
-    resetFormGenre () {
-      this.isChecked = false
+    // 他のジャンルが選ばれた時に自身をfalseにする
+    resetFormGenre (nowCheckedGenreName) {
+      if (this.genre.genre_name !== nowCheckedGenreName) {
+        this.isChecked = false
+      }
     }
   }
 }

--- a/components/atoms/SearchFormGenre.vue
+++ b/components/atoms/SearchFormGenre.vue
@@ -14,6 +14,7 @@
         :genre="genre"
         @formGenreCheckedEvent="formGenreChecked"
         @formGenreUncheckedEvent="formGenreUnchecked"
+        ref="child"
       />
     </v-chip-group>
   </div>
@@ -37,6 +38,7 @@ export default {
   },
   methods: {
     formGenreChecked (value) {
+      [...Array(this.genres.length)].map((_, i) => this.$refs.child[i].resetFormGenre(value))
       this.$emit('formGenreCheckedEvent', value)
     },
     formGenreUnchecked () {

--- a/components/atoms/SearchFormTag.vue
+++ b/components/atoms/SearchFormTag.vue
@@ -14,6 +14,7 @@
         :tag="tag"
         @formTagCheckedEvent="formTagChecked"
         @formTagUncheckedEvent="formTagUnchecked"
+        ref="child"
       />
     </v-chip-group>
   </div>
@@ -40,6 +41,7 @@ export default {
   },
   methods: {
     formTagChecked (value) {
+      [...Array(this.randomTags.length)].map((_, i) => this.$refs.child[i].resetFormTag(value))
       this.$emit('formTagCheckedEvent', value)
     },
     formTagUnchecked () {

--- a/components/atoms/Tag.vue
+++ b/components/atoms/Tag.vue
@@ -27,10 +27,14 @@ export default {
   methods: {
     toggleTag () {
       this.isChecked = !this.isChecked
-      if (this.isChecked === true) {
-        this.$emit('formTagCheckedEvent', this.tag.tag_name)
-      } else {
-        this.$emit('formTagUncheckedEvent')
+      this.isChecked
+        ? this.$emit('formTagCheckedEvent', this.tag.tag_name)
+        : this.$emit('formTagUncheckedEvent')
+    },
+    // 他のタグが選ばれた時に自身をfalseにする
+    resetFormTag (nowCheckedTagName) {
+      if (this.tag.tag_name !== nowCheckedTagName) {
+        this.isChecked = false
       }
     }
   }

--- a/store/modules/user.js
+++ b/store/modules/user.js
@@ -327,8 +327,8 @@ export const actions = {
   // ==================================================
   async destroyAccountGuest ({ rootState }) {
     await this.$axios.$delete(`/api/v1/users/${rootState.user.current.id}`)
-      .then(() => {
-        this.app.router.push('/logout')
-      })
+    // .then(() => {
+    //   this.app.router.push('/logout')
+    // })
   }
 }


### PR DESCRIPTION
# 修正内容
別のジャンル/タグ(v-chip)が選択された時、全v-chipコンポーネントに対して今チェックされたものでなければisCheckedをfalseにするメソッドを追加しました。