### PR TITLE
[fix] 投稿/ユーザーの縦断検索で前回結果を参照し続けるバグの修正

### DIFF
--- a/components/organisms/CommonSearch.vue
+++ b/components/organisms/CommonSearch.vue
@@ -1,0 +1,125 @@
+<script>
+import _ from 'lodash'
+import { mapActions } from 'vuex'
+export default {
+  props: {
+    keyword: {
+      type: String
+    },
+    genre: {
+      type: String
+    },
+    tag: {
+      type: String
+    }
+  },
+  watch: {
+    keyword () {
+      this.getFilteredPostsClear()
+      this.getFilteredUsersClear()
+      if (this.keyword !== '') {
+        this.delaySearchPosts()
+        this.delaySearchUsers()
+      }
+    },
+    genre () {
+      this.getFilteredPostsClear()
+      this.getFilteredUsersClear()
+      if (this.genre !== '') {
+        this.genreSearchPosts()
+        this.genreSearchUsers()
+      }
+    },
+    tag () {
+      this.getFilteredPostsClear()
+      this.getFilteredUsersClear()
+      if (this.tag !== '') {
+        this.tagSearchPosts()
+      }
+    }
+  },
+  methods: {
+    ...mapActions({
+      getFilteredPosts: 'modules/post/getFilteredPosts',
+      getFilteredPostsZero: 'modules/post/getFilteredPostsZero',
+      getFilteredPostsClear: 'modules/post/getFilteredPostsClear',
+      getFilteredUsers: 'modules/user/getFilteredUsers',
+      getFilteredUsersZero: 'modules/user/getFilteredUsersZero',
+      getFilteredUsersClear: 'modules/user/getFilteredUsersClear'
+    }),
+    keywordSearchPosts () {
+      this.$emit('startSearchEvent')
+      this.$axios.$get('api/v1/posts/search', {
+        params: {
+          post_keyword: this.keyword
+        }
+      })
+        .then((postsArray) => {
+          postsArray.length
+            ? this.getFilteredPosts(postsArray)
+            : this.getFilteredPostsZero()
+          this.$emit('stopSearchEvent')
+        })
+        .catch((error) => {
+          console.error(error)
+        })
+    },
+    genreSearchPosts () {
+      this.$emit('startSearchEvent')
+      this.$axios.$get('api/v1/posts/search', { params: { post_genre: this.genre } })
+        .then((postsArray) => {
+          postsArray.length
+            ? this.getFilteredPosts(postsArray)
+            : this.getFilteredPostsZero()
+          this.$emit('stopSearchEvent')
+        })
+        .catch((error) => {
+          console.error(error)
+        })
+    },
+    tagSearchPosts () {
+      this.$emit('startSearchEvent')
+      this.$axios.$get('api/v1/posts/search', { params: { post_tag: this.tag } })
+        .then((postsArray) => {
+          postsArray.length
+            ? this.getFilteredPosts(postsArray)
+            : this.getFilteredPostsZero()
+          this.$emit('stopSearchEvent')
+        })
+        .catch((error) => {
+          console.error(error)
+        })
+    },
+    keywordSearchUsers () {
+      this.$emit('startSearchEvent')
+      this.$axios.$get('api/v1/users/search', { params: { user_keyword: this.keyword } })
+        .then((usersArray) => {
+          usersArray.length
+            ? this.getFilteredUsers(usersArray)
+            : this.getFilteredUsersZero()
+          this.$emit('stopSearchEvent')
+        })
+        .catch((error) => {
+          console.error(error)
+        })
+    },
+    genreSearchUsers () {
+      this.$emit('startSearchEvent')
+      this.$axios.$get('api/v1/users/search', { params: { user_genre: this.genre } })
+        .then((usersArray) => {
+          usersArray.length
+            ? this.getFilteredUsers(usersArray)
+            : this.getFilteredUsersZero()
+          this.$emit('stopSearchEvent')
+        })
+        .catch((error) => {
+          console.error(error)
+        })
+    }
+  },
+  created () {
+    this.delaySearchPosts = _.debounce(this.keywordSearchPosts, 500)
+    this.delaySearchUsers = _.debounce(this.keywordSearchUsers, 500)
+  }
+}
+</script>

--- a/components/organisms/PostsFeedSearch.vue
+++ b/components/organisms/PostsFeedSearch.vue
@@ -1,5 +1,14 @@
 <template>
-  <div class="mx-auto">
+  <div>
+    <!-- 描画なし(scriptのみ) -->
+    <CommonSearch
+      :keyword="keyword"
+      :genre="genre"
+      :tag="tag"
+      @startSearchEvent="isLoading = true"
+      @stopSearchEvent="isLoading = false"
+    />
+    <!-- /描画なし(scriptのみ) -->
     <v-list-item v-if="isSearching">
       <v-list-item-title>
         <span>
@@ -46,7 +55,6 @@
 </template>
 
 <script>
-import _ from 'lodash'
 import { mapGetters, mapActions } from 'vuex'
 export default {
   props: {
@@ -74,98 +82,12 @@ export default {
       return this.keyword || this.genre || this.tag
     }
   },
-  watch: {
-    keyword () {
-      if (this.keyword !== '') {
-        this.delaySearch()
-      } else {
-        this.getFilteredPostsClear()
-      }
-    },
-    genre () {
-      if (this.genre !== '') {
-        this.genreSearchPosts()
-      } else {
-        this.getFilteredPostsClear()
-      }
-    },
-    tag () {
-      if (this.tag !== '') {
-        this.tagSearchPosts()
-      } else {
-        this.getFilteredPostsClear()
-      }
-    }
-  },
   methods: {
     ...mapActions({
       likePost: 'modules/post/likePost',
       unLikePost: 'modules/post/unLikePost',
-      destroyPost: 'modules/post/destroyPost',
-      getFilteredPosts: 'modules/post/getFilteredPosts',
-      getFilteredPostsZero: 'modules/post/getFilteredPostsZero',
-      getFilteredPostsClear: 'modules/post/getFilteredPostsClear'
-    }),
-    keywordSearchPosts () {
-      this.isLoading = true
-      this.$axios.$get('api/v1/posts/search', {
-        params: {
-          post_keyword: this.keyword
-        }
-      })
-        .then((postsArray) => {
-          if (postsArray.length) {
-            this.getFilteredPosts(postsArray)
-          } else {
-            this.getFilteredPostsZero()
-          }
-          this.isLoading = false
-        })
-        .catch((error) => {
-          console.error(error)
-        })
-    },
-    genreSearchPosts () {
-      this.isLoading = true
-      this.$axios.$get('api/v1/posts/search', {
-        params: {
-          post_genre: this.genre
-        }
-      })
-        .then((postsArray) => {
-          if (postsArray.length) {
-            this.getFilteredPosts(postsArray)
-          } else {
-            this.getFilteredPostsZero()
-          }
-          this.isLoading = false
-        })
-        .catch((error) => {
-          console.error(error)
-        })
-    },
-    tagSearchPosts () {
-      this.isLoading = true
-      this.$axios.$get('api/v1/posts/search', {
-        params: {
-          post_tag: this.tag
-        }
-      })
-        .then((postsArray) => {
-          if (postsArray.length) {
-            this.getFilteredPosts(postsArray)
-          } else {
-            this.getFilteredPostsZero()
-          }
-          this.isLoading = false
-        })
-        .catch((error) => {
-          console.error(error)
-        })
-    }
-  },
-  created () {
-    this.delaySearch = _.debounce(this.keywordSearchPosts, 500)
+      destroyPost: 'modules/post/destroyPost'
+    })
   }
 }
 </script>

--- a/components/organisms/UsersFeedSearch.vue
+++ b/components/organisms/UsersFeedSearch.vue
@@ -1,5 +1,13 @@
 <template>
   <div>
+    <!-- 描画なし(scriptのみ) -->
+    <CommonSearch
+      :keyword="keyword"
+      :genre="genre"
+      @startSearchEvent="isLoading = true"
+      @stopSearchEvent="isLoading = false"
+    />
+    <!-- /描画なし(scriptのみ) -->
     <v-list-item v-if="isSearching">
       <v-list-item-title>
         <span>
@@ -45,7 +53,6 @@
 </template>
 
 <script>
-import _ from 'lodash'
 import { mapGetters, mapActions } from 'vuex'
 export default {
   props: {
@@ -70,71 +77,11 @@ export default {
       return this.keyword || this.genre
     }
   },
-  watch: {
-    keyword () {
-      if (this.keyword !== '' && this.keyword !== null) {
-        this.delaySearch()
-      } else {
-        this.getFilteredPostsClear()
-      }
-    },
-    genre () {
-      if (this.genre !== '') {
-        this.genreSearchUsers()
-      } else {
-        this.getFilteredPostsClear()
-      }
-    }
-  },
   methods: {
     ...mapActions({
       follow: 'modules/user/follow',
-      unfollow: 'modules/user/unfollow',
-      getFilteredUsers: 'modules/user/getFilteredUsers',
-      getFilteredUsersZero: 'modules/user/getFilteredUsersZero',
-      getFilteredPostsClear: 'modules/user/getFilteredUsersClear'
-    }),
-    keywordSearchUsers () {
-      this.isLoading = true
-      this.$axios.$get('api/v1/users/search', {
-        params: {
-          user_keyword: this.keyword
-        }
-      })
-        .then((usersArray) => {
-          if (usersArray.length) {
-            this.getFilteredUsers(usersArray)
-          } else {
-            this.getFilteredUsersZero()
-          }
-          this.isLoading = false
-        })
-        .catch((error) => {
-          console.error(error)
-        })
-    },
-    genreSearchUsers () {
-      this.isLoading = true
-      this.$axios.$get('api/v1/users/search', {
-        params: {
-          user_genre: this.genre
-        }
-      })
-        .then((usersArray) => {
-          if (usersArray.length) {
-            this.getFilteredUsers(usersArray)
-          } else {
-            this.getFilteredUsersZero()
-          }
-          this.isLoading = false
-        })
-        .catch((error) => {
-          console.error(error)
-        })
-    }
-  },
-  created () {
-    this.delaySearch = _.debounce(this.keywordSearchUsers, 500)
+      unfollow: 'modules/user/unfollow'
+    })
   }
 }
 </script>

--- a/store/modules/post.js
+++ b/store/modules/post.js
@@ -292,6 +292,7 @@ export const actions = {
     commit('setUserPostsClear')
   },
   getFilteredPostsClear ({ commit }) {
+    console.log('getFilteredPostsClear')
     commit('setFilteredPostsClear')
   },
   // ==================================================

--- a/store/modules/user.js
+++ b/store/modules/user.js
@@ -188,6 +188,7 @@ export const actions = {
     commit('setUserClear')
   },
   getFilteredUsersClear ({ commit }) {
+    console.log('getFilteredUsersClear')
     commit('setFilteredUsersClear')
   },
   // ==================================================


### PR DESCRIPTION
以下の修正を実施しました。
- CommonSearch.vueの新規作成
- UserFeedSearch.vue、PostFeedSearch.vueの検索ロジックをCommonSearch.vueに切り出し
